### PR TITLE
reset newTaskFlag on when servicing new task

### DIFF
--- a/src/Accelerating.java
+++ b/src/Accelerating.java
@@ -7,6 +7,7 @@ public class Accelerating implements DroneState {
     @Override
     public void reqServiceZone(Drone context) {
         // The drone can continue to accelerate, it will now travel towards a new direction
+        context.accelerate();
     }
 
     /**

--- a/src/Drone.java
+++ b/src/Drone.java
@@ -67,7 +67,6 @@ public class Drone implements Runnable {
     public void run() {
         while (true) {
             if (newTaskFlag) {
-                newTaskFlag = false;
                 System.out.println("[" + Thread.currentThread().getName() + id + "]: "
                         + "Drone has received an new task: " + currTask.getTaskType() + " @ zone#" + currTask.getZone().getId());
                 handleNewTask();
@@ -86,6 +85,8 @@ public class Drone implements Runnable {
      * Depending on the task type, it triggers the corresponding event request.
      */
     private void handleNewTask() {
+        newTaskFlag = false;
+
         switch (currTask.getTaskType()) {
             case DroneTaskType.SERVICE_ZONE:
                 eventReqServiceZone();

--- a/src/Takeoff.java
+++ b/src/Takeoff.java
@@ -7,6 +7,7 @@ public class Takeoff implements DroneState {
     @Override
     public void reqServiceZone(Drone context) {
         // destination has just changed, we can continue to take off
+        context.takeoff();
     }
 
     /**


### PR DESCRIPTION
Fixes # [95](https://github.com/hubertdang/fire-drone-swarm/issues/95)

## Description

- newTaskFlag now being clearing when handling a new task.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test

Are additional unit tests were required?
- [x] Yes
- [x] No

If additional unit tests were required, did you add them?
- [x] Yes
- [ ] No
- [x] N/A

All unit tests pass?
- [x] Yes
- [ ] No
- [ ] N/A

## Checklist:

- [x] I formatted my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If new unit tests are required, I opened an issue for them
