### PR TITLE
added action to Drone's Flying state when event reqServiceZone comes

### DIFF
--- a/src/Flying.java
+++ b/src/Flying.java
@@ -6,7 +6,7 @@ public class Flying implements DroneState {
      */
     @Override
     public void reqServiceZone(Drone context) {
-        // is already at flying altitude and height, can continue flying to new direction
+        context.fly();
     }
 
     /**


### PR DESCRIPTION
Fixes # (138)

## Description
When a Drone is in a Flying state, and its droneController dispatches SERVICE_ZONE task to it, it will stop all the behaviours. 

* call drone.fly() in Flying state when a reqServiceZone event happens

tested with 10 drones and a couple of "10 events",  to let drones reroute while in a flying state, the problem should be gone now 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test

## Testing information

Replace this with information on how you tested your changes here. Maybe include the log if that helps show what works.

Are additional unit tests were required?
- [ ] Yes
- [ ] No

If additional unit tests were required, did you add them?
- [ ] Yes
- [ ] No
- [ ] N/A

All unit tests pass?
- [ ] Yes
- [ ] No
- [ ] N/A

## Checklist:

- [ ] I formatted my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If new unit tests are required, I opened an issue for them
