### PR TITLE
Finite Agent Capacity Handling Bug Scheduler

### DIFF
--- a/src/DroneRequestHandler.java
+++ b/src/DroneRequestHandler.java
@@ -64,13 +64,16 @@ public class DroneRequestHandler extends MessagePasser implements Runnable {
                         + " | POSITION = " + droneInfo.getPosition()
                         + " | TANK = " + String.format("%.2f L", droneInfo.getAgentTankAmount()));
 
+                scheduler.processDroneInfo(droneInfo, this);
+
                 if (droneInfo.stateID == DroneStateID.EMPTY_TANK) {
                     scheduler.getZonesOnFire().get(droneInfo.zoneToService).removeDrone(droneInfo);
-                    // replace map value of zone
-                    scheduler.getZonesOnFire().compute(droneInfo.zoneToService, (k, oldTriageStruct) -> oldTriageStruct);
-                    System.out.println("NEW " + scheduler.getZonesOnFire().get(droneInfo.zoneToService));
+                    // replace value key pair in zonesOnFire to update the key (zone agent needed)
+                    ZoneTriageInfo copyTriageInfo = scheduler.getZonesOnFire().get(droneInfo.zoneToService);
+                    scheduler.getZonesOnFire().remove(droneInfo.zoneToService);
+                    scheduler.getZonesOnFire().put(droneInfo.zoneToService, copyTriageInfo);
                 }
-                scheduler.processDroneInfo(droneInfo, this);
+
                 scheduler.dispatchActions(this, droneInfo.droneID);
 
             } else if (droneInfo.fault != FaultID.NONE) {

--- a/src/DroneRequestHandler.java
+++ b/src/DroneRequestHandler.java
@@ -68,9 +68,9 @@ public class DroneRequestHandler extends MessagePasser implements Runnable {
 
                 if (droneInfo.stateID == DroneStateID.EMPTY_TANK) {
                     scheduler.getZonesOnFire().get(droneInfo.zoneToService).removeDrone(droneInfo);
-                    // replace value key pair in zonesOnFire to update the key (zone agent needed)
-                    ZoneTriageInfo copyTriageInfo = scheduler.getZonesOnFire().get(droneInfo.zoneToService);
-                    scheduler.getZonesOnFire().remove(droneInfo.zoneToService);
+                    // replace key value pair in zonesOnFire to update the immutable key (zone agent needed)
+                    ZoneTriageInfo copyTriageInfo = scheduler.getZonesOnFire()
+                            .remove(droneInfo.zoneToService);
                     scheduler.getZonesOnFire().put(droneInfo.zoneToService, copyTriageInfo);
                 }
 


### PR DESCRIPTION
Fixes # (129)

## Description

Zone Agent amount would reset after a drone recalls when EMPTY_TANK state is reached. Resulting in infinite loop of
SERVICE_ZONE->RECALL(EMPTY_TANK)->SERVICE_ZONE(same agent amount needed).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Test

## Testing information

No tests created, manual testing only:
![image](https://github.com/user-attachments/assets/c5b68069-6ed8-4a76-a76d-7293d7a76edf)

Are additional unit tests were required?
- [ ] Yes
- [x] No

If additional unit tests were required, did you add them?
- [ ] Yes
- [ ] No
- [x] N/A

All unit tests pass?
- [ ] Yes
- [ ] No
- [ ] N/A

## Checklist:

- [ ] I formatted my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If new unit tests are required, I opened an issue for them
